### PR TITLE
don't use incomplete address_stub for matching ;fixes #2

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: parcel
 Title: Convert real-world street addresses to county parcel identifiers
-Version: 0.1
+Version: 0.1.1
 Authors@R: 
     person("Cole", "Brokamp", , "cole@colebrokamp.com", role = c("aut", "cre"),
            comment = c(ORCID = "0000-0002-0289-3151"))

--- a/R/data.R
+++ b/R/data.R
@@ -8,7 +8,7 @@
 #'
 #' The parcel identifiers and a property address (consisting of
 #' property_addr_number, property_addr_street, property_addr_suffix)
-#' for each parcel are "hashdressed" by applying `address_expand()`
+#' for each parcel are `hashdress()`ed using the parsed street number and street name.
 #' This object is used to match parcel identifiers
 #' to hashdresses computed on other, real-world addresses. Note that
 #' the five digit ZIP code is not included in CAGIS data, and wasn't used to

--- a/R/hashdress.R
+++ b/R/hashdress.R
@@ -10,6 +10,9 @@
 #' (i.e. "hashdress") can be used to link to other addresses hashdressed
 #' using the same version of this package.
 #'
+#' Any input address for which at least one of the `address_stub_components` cannot be found
+#' will result in a missing `stub_address` and it will not be expanded nor hashed.
+#'
 #' Each call to DeGAUSS is cached to disk (`data-raw` folder in working directory),
 #' making repetative function calls on the same data nearly instant.
 #' @param .x a tibble containing an `address` column
@@ -57,13 +60,15 @@ hashdress <- function(.x,
     dplyr::select(.id, address) |>
     dplyr::distinct() |>
     degauss_run("postal", degauss_postal_version, quiet = quiet) |>
-    dplyr::select(-address) |>
+    # if there are NA in any of the "address_stub_components", then don't create partial address_stub
+    dplyr::select(c(.id, tidyselect::any_of(address_stub_components))) |>
+    stats::na.omit() |>
     tidyr::unite(
       col = "address_stub",
       tidyselect::any_of(address_stub_components),
-      sep = " ", na.rm = TRUE, remove = FALSE
+      sep = " "
     ) |>
-    dplyr::select(.id, address = address_stub)
+    dplyr::rename(address = address_stub)
 
   message("expanding addresses...")
   d_expand <-
@@ -119,9 +124,11 @@ add_parcel_id <- function(.x, quiet = TRUE) {
     address_stub_components = c("parsed.house_number", "parsed.road"),
     quiet = quiet
   )
+
   d$parcel <- purrr::map(d$hashdresses, ~ cagis_hashdresses[., parcel_id])
+
   d |>
     dplyr::rowwise() |>
-    dplyr::mutate(parcel_id = list(unique(parcel))) |>
-    dplyr::select(-address_stub, -expanded_addresses, -hashdresses, -parcel)
+    dplyr::mutate(parcel_id = list(unique(as.character(parcel)))) |>
+    dplyr::select(-expanded_addresses, -hashdresses, -parcel)
 }

--- a/R/hashdress.R
+++ b/R/hashdress.R
@@ -1,8 +1,8 @@
 #' 'expand' and hash addresses
 #'
 #' The DeGAUSS [`postal`](https://degauss.org/postal/) container is used first
-#' to create clean addresses consisting of the parsed `house_number`, `road`,
-#' and first five digits of `postcode`. It is used again to expand these based on abbreviations.
+#' to create clean addresses consisting of the parsed components specified in
+#' `address_stub_components`.It is used again to expand these based on abbreviations.
 #' Because each input address will likely result in more than one expanded address,
 #' the newly added `expanded_addresses` column is a list-col.
 #' Each `expanded_address` is hashed using the 'spookyhash' algorithm and also
@@ -51,8 +51,7 @@ hashdress <- function(.x,
   fc <- memoise::cache_filesystem(fs::path(fs::path_wd(), "degauss_cache"))
   degauss_run <- memoise::memoise(dht::degauss_run, cache = fc, omit_args = "quiet")
 
-  d_in <- .x |>
-    dplyr::mutate(.id = dplyr::row_number())
+  d_in <- .x |> dplyr::mutate(.id = dplyr::row_number())
 
   message("parsing addresses...")
   d_stub <-

--- a/man/cagis_hashdresses.Rd
+++ b/man/cagis_hashdresses.Rd
@@ -5,7 +5,7 @@
 \alias{cagis_hashdresses}
 \title{CAGIS hashdresses}
 \format{
-An object of class \code{data.table} (inherits from \code{data.frame}) with 529165 rows and 3 columns.
+An object of class \code{data.table} (inherits from \code{data.frame}) with 528483 rows and 4 columns.
 }
 \usage{
 cagis_hashdresses
@@ -13,7 +13,7 @@ cagis_hashdresses
 \description{
 The parcel identifiers and a property address (consisting of
 property_addr_number, property_addr_street, property_addr_suffix)
-for each parcel are "hashdressed" by applying \code{address_expand()}
+for each parcel are \code{hashdress()}ed using the parsed street number and street name.
 This object is used to match parcel identifiers
 to hashdresses computed on other, real-world addresses. Note that
 the five digit ZIP code is not included in CAGIS data, and wasn't used to

--- a/man/hashdress.Rd
+++ b/man/hashdress.Rd
@@ -39,6 +39,9 @@ returned as a list col. These combinations of hashes for all expanded address
 using the same version of this package.
 }
 \details{
+Any input address for which at least one of the \code{address_stub_components} cannot be found
+will result in a missing \code{stub_address} and it will not be expanded nor hashed.
+
 Each call to DeGAUSS is cached to disk (\code{data-raw} folder in working directory),
 making repetative function calls on the same data nearly instant.
 }

--- a/man/hashdress.Rd
+++ b/man/hashdress.Rd
@@ -29,8 +29,8 @@ components to use to construct the address stub used for expansion and hashing}
 }
 \description{
 The DeGAUSS \href{https://degauss.org/postal/}{\code{postal}} container is used first
-to create clean addresses consisting of the parsed \code{house_number}, \code{road},
-and first five digits of \code{postcode}. It is used again to expand these based on abbreviations.
+to create clean addresses consisting of the parsed components specified in
+\code{address_stub_components}.It is used again to expand these based on abbreviations.
 Because each input address will likely result in more than one expanded address,
 the newly added \code{expanded_addresses} column is a list-col.
 Each \code{expanded_address} is hashed using the 'spookyhash' algorithm and also

--- a/tests/testthat/test-cagis_parcels.R
+++ b/tests/testthat/test-cagis_parcels.R
@@ -28,6 +28,7 @@ test_that("add_parcel_id works", {
     tidyr::unnest(cols = c(parcel_id), keep_empty = TRUE)
 
   expect_equal(is.na(d$parcel_id), c(rep(FALSE, 4), rep(TRUE, 5)))
+  expect_equal(is.na(d$address_stub), c(rep(FALSE, 7), rep(TRUE, 2)))
 
   expect_equal(d$parcel_id[1:2], rep("2170054005900", 2))
 })

--- a/tests/testthat/test-cagis_parcels.R
+++ b/tests/testthat/test-cagis_parcels.R
@@ -18,22 +18,30 @@ test_that("add_parcel_id works", {
         "5377 Bahama Te Apt 1 Cincinnati Ohio 45223",
         "1851 Campbell Dr Hamilton Ohio 45011", # outside hamilton county
         "2 Maplewood Dr Ryland Heights, KY 41015", # outside ohio
-        "222 East Central Parkway Cincinnati OH 45220" # non-residential
+        "222 East Central Parkway Cincinnati OH 45220", # non-residential
+        "736 South fredshuttles Apt 3 CINCINNATI Ohio 45229", # parsed as "house", not "house_number" and "road"
+        "NA"
       ),
-      id = letters[1:7]
+      id = letters[1:9]
     ) |>
     add_parcel_id() |>
-    tidyr::unnest(cols = c(parcel_id))
+    tidyr::unnest(cols = c(parcel_id), keep_empty = TRUE)
 
-  expect_equal(is.na(d$parcel_id), c(rep(FALSE, 4), rep(TRUE, 3)))
+  expect_equal(is.na(d$parcel_id), c(rep(FALSE, 4), rep(TRUE, 5)))
 
   expect_equal(d$parcel_id[1:2], rep("2170054005900", 2))
 })
 
-test_that("hashdress works on addresses missing ZIP codes", {
+test_that("hashdress returns missing on addresses missing one of the address_stub_components", {
   skip_on_ci()
+
   tibble::tibble(address = c("222 East Central Parkway", "222 East Central Parkway 45202")) |>
     hashdress() |>
     dplyr::pull(address_stub) |>
-    expect_equal(c("222 east central parkway", "222 east central parkway 45202"))
+    expect_equal(c(NA, "222 east central parkway 45202"))
+
+  tibble::tibble(address = c("222 East Central Parkway", "222 East Central Parkway 45202")) |>
+    hashdress(address_stub_components = c("parsed.house_number", "parsed.road")) |>
+    dplyr::pull(address_stub) |>
+    expect_equal(c("222 east central parkway", "222 east central parkway"))
 })

--- a/tests/testthat/test-hashdress.R
+++ b/tests/testthat/test-hashdress.R
@@ -8,43 +8,31 @@ test_that("hashdress works", {
         "352 Helen St Cincinnati OH 45202",
         "5377 Bahama Ter Apt 1 Cincinnati Ohio 45223",
         "5377 Bahama Te Apt 1 Cincinnati Ohio 45223",
-        "1851 Campbell Dr Hamilton Ohio 45011",
-        "2 Maplewood Dr Ryland Heights, KY 41015"
+        "1851 Campbell Dr Hamilton Ohio 45011", # outside hamilton county
+        "2 Maplewood Dr Ryland Heights, KY 41015", # outside ohio
+        "222 East Central Parkway Cincinnati OH 45220", # non-residential
+        "736 South fredshuttles Apt 3 CINCINNATI Ohio 45229", # parsed as "house", not "house_number" and "road"
+        "NA"
       ),
-      id = letters[1:7]
+      id = letters[1:10]
     )
 
   d_hd <- hashdress(d, quiet = TRUE)
 
   expect_equal(names(d_hd), c("address", "id", "address_stub", "expanded_addresses", "hashdresses"))
-  expect_equal(nrow(d_hd), 7)
+  expect_equal(nrow(d_hd), 10)
 
-  d_hd_long <-
-    d_hd |>
-    dplyr::rowwise(address) |>
-    dplyr::summarize(expanded_address = expanded_addresses, hashdress = hashdresses, .groups = "drop")
+  d_hd_long <- tidyr::unnest(d_hd, cols = hashdresses, keep_empty = TRUE)
 
-  expect_equal(nrow(d_hd_long), 11)
+  expect_equal(nrow(d_hd_long), 14)
 
-  expect_equal(d_hd_long[["hashdress"]][1], "c8368081d566abf9dc869c5dc99dc802")
+  expect_equal(d_hd_long[["hashdresses"]][1], "c8368081d566abf9dc869c5dc99dc802")
 
-  expect_equal(
-    d_hd_long$expanded_address,
-    c(
-      "224 woolper avenue 45220",
-      "222 east central parkway 45220",
-      "352 helen saint 45202",
-      "352 helen street 45202",
-      "5377 bahama terrace 45223",
-      "5377 bahama ter 45223",
-      "5377 bahama te 45223",
-      "1851 campbell doctor 45011",
-      "1851 campbell drive 45011",
-      "2 maplewood doctor 41015",
-      "2 maplewood drive 41015"
-    )
-  )
+  expect_equal(sum(is.na(d_hd_long$hashdresses)), 2)
 
-  expect_equal(sum(is.na(d_hd_long)), 0)
+  expect_equal(sum(is.na(d_hd_long$hashdresses)), 2)
+
+  expect_equal(sum(is.na(d_hd_long$address)), 0)
+
 })
 


### PR DESCRIPTION
- [x] don't match/expand when address stub is incomplete
- [x] rerun cagis cleaning with updated package version
- [x] ensure NAs are not matched in add_parcel_id (this is taken care of automatically by never using incomplete address stubs from CAGIS for matching)